### PR TITLE
fixed hardcoded file path separator - replaced with generic one

### DIFF
--- a/lzma_decompress.py
+++ b/lzma_decompress.py
@@ -35,9 +35,9 @@ def main(args) -> None:
 
     for path in paths:
         pickled_data = compress_pickle.load(path, compression="lzma")
-        filename = path.split("/")[-1].replace(".lzma", ".p")  # get the filename and convert .lzma extension to .p
+        filename = path.split(os.path.sep)[-1].replace(".lzma", ".p")  # get the filename and convert .lzma extension to .p
 
-        file_path = os.path.join(*path.split("/")[-4:-1])  # extract the directory tree
+        file_path = os.path.join(*path.split(os.path.sep)[-4:-1])  # extract the directory tree
         path_to_save = os.path.join(args.path_to_save,
                                     file_path)  # append the tree with the path to the saving directory
         os.makedirs(path_to_save, exist_ok=True)  # create directory tree if doesn't already exist


### PR DESCRIPTION
Issue : 
file path separator was hardcoded as forward slash ("/"). This caused issue in windows OS.

Fix:
Replaced it with generic system variable (os.path.sep)

Observation:
Code ran successfully in windows with the fix